### PR TITLE
Fix missing whitespace after elemcoil macro

### DIFF
--- a/docs/equations/equations.tex
+++ b/docs/equations/equations.tex
@@ -15,6 +15,7 @@
 \usepackage{listings}
 \usepackage{hyperref}
 \usepackage{cancel}
+\usepackage{xspace}
 \hypersetup{
     bookmarks=true,         % show bookmarks bar?
     unicode=false,          % non-Latin characters in Acrobat’s bookmarks
@@ -67,7 +68,7 @@
 \newcommand{\lk}{\left}
 \newcommand{\rk}{\right}
 \newcommand{\ieq}{\stackrel{!}{=}}
-\newcommand{\elemcoil}{\textsf{ElemCo.jl}}
+\newcommand{\elemcoil}{\textsf{ElemCo.jl}\xspace}
 \newcommand{\quantwo}{\textsf{Quantwo} }
 \newcommand{\cmd}[1]{\texttt{#1}}
 % for presubscripts and presuperscripts (e.g., \pre{^x}U_a)


### PR DESCRIPTION
Hi!
I like the idea of the "equations" file a lot. I noticed that the `\elemcoil` would eat the following whitespace, which it does not anymore with this change.
[equations.pdf](https://github.com/user-attachments/files/26976366/equations.pdf)
Given that this seems to be a release rather than a development repository, feel free to close this PR and incorporate it by other means if that fits your workflow better. I just thought this might be useful.
